### PR TITLE
debian: lowercase unstable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# For next release
+  * **Tom Siewert**
+    * debian: lowercase unstable
+
+*Not released yet*
+
 # Minor Release v0.6.0 (2023-01-18)
   * **Markus Freitag**
     * pkg/gitconfig: replace character-based with ini config parser

--- a/cmd/debian.go
+++ b/cmd/debian.go
@@ -43,7 +43,7 @@ var (
 	temp            *template.Template
 	releases        parser.Releases
 	out             = bytes.NewBufferString("")
-	defaultTemplate = `{{.BinaryName}} ({{.Version}}) UNSTABLE; urgency=medium
+	defaultTemplate = `{{.BinaryName}} ({{.Version}}) unstable; urgency=medium
 
   {{.Text}}
 


### PR DESCRIPTION
unstable is lowercase in debian, not capitalised.